### PR TITLE
feat: add read-only option chain, quote, and index tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,19 @@ The MCP server provides the following tools for LLM interaction:
 ### 2. Market Data
 - **get_historical_data**: Retrieve historical market data with configurable duration, bar size, and data type
 
-### 3. News
+### 3. Options
+- **get_option_chain**: List option-chain parameters (expirations and strikes) for an underlying, with strike-range filtering and pagination
+- **get_option_quotes**: Batch bid/ask/last/close and model IV/delta for a list of option strikes; defaults to delayed-frozen data (no OPRA subscription required)
+- **get_index_quote**: Spot quote (last/close/bid/ask) for an index, useful for strike-from-spot calculations
+
+### 4. News
 - **get_news**: Retrieve current news articles for a contract
 - **get_historical_news**: Retrieve historical news articles within a date range
 
-### 4. Fundamental Data
+### 5. Fundamental Data
 - **get_fundamental_data**: Retrieve fundamental data including financial summaries, ownership, financial statements, and more
 
-### 5. Portfolio and Account Information
+### 6. Portfolio and Account Information
 - **get_portfolio**: Retrieve portfolio positions and details
 - **get_account_summary**: Retrieve account summary information
 - **get_positions**: Retrieve current positions with contract metadata, including option expiry/strike/right/multiplier fields
@@ -237,6 +242,22 @@ ticker_to_conid(symbol, sec_type="STK", exchange="SMART", currency="USD")
 get_historical_data(symbol, duration="1 M", bar_size="1 day", data_type="TRADES", exchange="SMART", currency="USD")
 ```
 
+### Options
+```
+get_option_chain(symbol, sec_type="IND", exchange="CBOE", currency="USD", trading_class="", min_strike=0.0, max_strike=0.0, max_strikes=20, strike_offset=0)
+get_option_quotes(symbol, expiry, right, strikes, exchange="SMART", currency="USD", trading_class="", use_delayed=True)
+get_index_quote(symbol, exchange="CBOE", currency="USD", use_delayed=True)
+```
+
+`get_option_chain` returns the available expirations plus a strike window filtered
+to `[min_strike, max_strike]` (0 = unbounded) and paginated with `max_strikes`
+(default 20) and `strike_offset`; the output states how to page to the next window.
+When an underlying lists several trading classes (e.g. SPX and SPXW), pass
+`trading_class` to page one chain. `get_option_quotes` fetches up to 20 unique
+strikes per call (duplicates are ignored, to respect IB pacing) and defaults to
+delayed-frozen data, so it works without an OPRA subscription — pass
+`use_delayed=false` for live data. Both tools are read-only.
+
 ### News
 ```
 get_news(symbol, provider_codes="", exchange="SMART", currency="USD")
@@ -272,6 +293,8 @@ Once connected to an LLM through MCP, you can ask questions like:
 
 - "Look up the contract details for AAPL"
 - "Get the last month of daily historical data for TSLA"
+- "Show the XSP option chain strikes between 400 and 550"
+- "Get put quotes for XSP expiry 20261218 at strikes 440, 450 and 460"
 - "What are the recent news articles for Microsoft?"
 - "Show me the financial summary for Google"
 - "What positions do I currently have in my portfolio?"

--- a/ib_mcp/server.py
+++ b/ib_mcp/server.py
@@ -6,7 +6,9 @@ for simpler registration and JSON-schema generation from type hints.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import math
 from typing import Annotated, Any
 
 import defusedxml.ElementTree as ET
@@ -15,6 +17,14 @@ from fastmcp import FastMCP
 from pydantic import Field
 
 logger = logging.getLogger(__name__)
+
+# Maximum option contracts fetched per get_option_quotes call, to respect IB
+# market-data pacing limits.
+_MAX_QUOTE_BATCH = 20
+
+# Ceiling (seconds) for waiting on streaming market data to deliver a fresh
+# update before returning quotes; typical calls finish much sooner.
+_QUOTE_SETTLE_SECONDS = 4.0
 
 
 def _format_markdown_table(headers: list[str], rows: list[list[str]]) -> str:
@@ -90,6 +100,276 @@ def _format_positions_markdown(positions: list[Any], account: str = "") -> str:
     return f"# Positions{account_title}\n\n{table}"
 
 
+def _fmt_num(value: object, decimals: int = 2) -> str:
+    """Format a number to fixed decimals; blank for None/NaN.
+
+    Used for model greeks, which keep their sign (a put delta is negative).
+    """
+    if value is None:
+        return ""
+    if isinstance(value, int | float):
+        num = float(value)
+        if math.isnan(num):
+            return ""
+        return f"{num:.{decimals}f}"
+    return str(value)
+
+
+def _fmt_price(value: object, decimals: int = 2) -> str:
+    """Format a market price; blank for None/NaN and IB's no-data sentinels.
+
+    IB reports -1 (or 0 with zero size) when a side has no quote, so
+    non-positive values render blank rather than as misleading prices.
+    """
+    if isinstance(value, int | float) and not math.isnan(float(value)):
+        if float(value) <= 0:
+            return ""
+    return _fmt_num(value, decimals=decimals)
+
+
+def _fmt_strike(value: object) -> str:
+    """Format a strike without trailing zeros (450.0 -> '450', 452.5 -> '452.5')."""
+    if value is None:
+        return ""
+    try:
+        num = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return str(value)
+    if math.isnan(num):
+        return ""
+    return f"{num:g}"
+
+
+def _strike_range_suffix(min_strike: float, max_strike: float) -> str:
+    """Describe the active strike filter for headers/footers ('' when unbounded)."""
+    if min_strike > 0 and max_strike > 0:
+        return f" in range [{_fmt_strike(min_strike)}, {_fmt_strike(max_strike)}]"
+    if min_strike > 0:
+        return f" at or above {_fmt_strike(min_strike)}"
+    if max_strike > 0:
+        return f" at or below {_fmt_strike(max_strike)}"
+    return ""
+
+
+def _format_option_chain_markdown(
+    symbol: str,
+    sec_type: str,
+    chains: list[Any],
+    min_strike: float = 0.0,
+    max_strike: float = 0.0,
+    max_strikes: int = 20,
+    strike_offset: int = 0,
+) -> str:
+    """Render chain parameters: expirations + a filtered, paginated strike window.
+
+    ``chains`` come from ``reqSecDefOptParams`` (contract reference data, not live
+    prices). Strikes are sorted ascending and expirations chronologically before
+    filtering/paginating, so ``strike_offset`` is deterministic across calls.
+    """
+    if not chains:
+        return f"No option chain parameters found for {symbol}"
+
+    suffix = _strike_range_suffix(min_strike, max_strike)
+
+    # Collapse chains that are identical apart from their routing exchange
+    # (e.g. XSP lists the same class on IBUSOPT, CBOE and SMART). The key
+    # carries everything rendered per group; values collect the exchanges.
+    groups: dict[tuple[Any, Any, tuple[Any, ...], tuple[float, ...]], list[str]] = {}
+    for chain in chains:
+        key = (
+            getattr(chain, "tradingClass", ""),
+            getattr(chain, "multiplier", ""),
+            tuple(sorted(getattr(chain, "expirations", []) or [])),
+            tuple(sorted(float(s) for s in (getattr(chain, "strikes", []) or []))),
+        )
+        exchanges = groups.setdefault(key, [])
+        exch = getattr(chain, "exchange", "")
+        if exch and exch not in exchanges:
+            exchanges.append(exch)
+
+    single_group = len(groups) == 1
+    out = [f"# Option Chain for {symbol} ({sec_type})", ""]
+    for (tclass, mult, expirations, strikes), exchanges in groups.items():
+        filtered = [
+            s
+            for s in strikes
+            if (min_strike <= 0 or s >= min_strike)
+            and (max_strike <= 0 or s <= max_strike)
+        ]
+        total = len(filtered)
+        window = filtered[strike_offset : strike_offset + max_strikes]
+
+        out.append(
+            f"## Trading Class {tclass} "
+            f"(exchanges: {', '.join(exchanges)}, multiplier {mult})"
+        )
+        out.append("")
+        out.append(f"**Expirations ({len(expirations)})**: {', '.join(expirations)}")
+        out.append("")
+        if window:
+            first = strike_offset + 1
+            last = strike_offset + len(window)
+            shown = ", ".join(_fmt_strike(s) for s in window)
+            out.append(f"**Strikes {first}–{last} of {total}{suffix}**: {shown}")
+            if last < total and single_group:
+                out.append("")
+                out.append(
+                    f"*Showing strikes {first}–{last} of {total}{suffix}; "
+                    f"pass strike_offset={last} for the next page.*"
+                )
+        elif total:
+            out.append(
+                f"**Strikes (0 of {total}{suffix})**: strike_offset="
+                f"{strike_offset} is past the last strike "
+                f"(valid offsets: 0-{total - 1})"
+            )
+        else:
+            out.append(f"**Strikes (0 of 0{suffix})**: none in range")
+        out.append("")
+
+    if not single_group:
+        classes = ", ".join(sorted({str(key[0]) for key in groups}))
+        out.append(
+            f"*{len(groups)} option chains returned (trading classes: "
+            f"{classes}); strike_offset applies to each strike list "
+            "independently — pass trading_class to page one chain reliably.*"
+        )
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+def _format_option_quotes_markdown(
+    symbol: str,
+    expiry: str,
+    right: str,
+    tickers: list[Any],
+    use_delayed: bool = True,
+    requested_strikes: list[float] | None = None,
+) -> str:
+    """Render a batch of option quotes as a markdown table (NaN/None -> blank).
+
+    If ``requested_strikes`` is given, strikes that did not qualify (not listed
+    for this expiry) are reported so the caller isn't left guessing.
+    """
+
+    def _strike_of(ticker: object) -> float:
+        contract = getattr(ticker, "contract", None)
+        try:
+            return float(getattr(contract, "strike", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    present = {round(_strike_of(t), 6) for t in tickers}
+    missing = (
+        [s for s in requested_strikes if round(float(s), 6) not in present]
+        if requested_strikes
+        else []
+    )
+    missing_note = ""
+    if missing:
+        listed = ", ".join(_fmt_strike(s) for s in missing)
+        missing_note = f"*Not listed for this expiry (skipped): {listed}*"
+
+    if not tickers:
+        base = f"No option quotes found for {symbol} {expiry} {right}"
+        return f"{base}\n\n{missing_note}" if missing_note else base
+
+    headers = ["Strike", "Bid", "Ask", "Last", "Close", "IV", "Delta"]
+    rows = []
+    und_price = ""
+    for ticker in sorted(tickers, key=_strike_of):
+        contract = getattr(ticker, "contract", None)
+        greeks = getattr(ticker, "modelGreeks", None)
+        if not und_price:
+            und_price = _fmt_price(getattr(greeks, "undPrice", None))
+        rows.append(
+            [
+                _fmt_strike(getattr(contract, "strike", None)),
+                _fmt_price(getattr(ticker, "bid", None)),
+                _fmt_price(getattr(ticker, "ask", None)),
+                _fmt_price(getattr(ticker, "last", None)),
+                _fmt_price(getattr(ticker, "close", None)),
+                _fmt_num(getattr(greeks, "impliedVol", None), decimals=4),
+                _fmt_num(getattr(greeks, "delta", None), decimals=4),
+            ]
+        )
+
+    table = _format_markdown_table(headers, rows)
+    data_type = "delayed-frozen" if use_delayed else "live"
+    header_bits = [
+        f"**Expiry**: {expiry}",
+        f"**Right**: {right}",
+        f"**Data**: {data_type}",
+    ]
+    if und_price:
+        header_bits.append(f"**Underlying**: {und_price}")
+    lines = [
+        f"# Option Quotes for {symbol} {expiry} {right}",
+        " | ".join(header_bits),
+        "",
+        table,
+        "",
+        "*IV/Delta from IB model greeks; blank cells mean no data or no "
+        "bid (illiquid strike or market closed).*",
+    ]
+    if missing_note:
+        lines.append("")
+        lines.append(missing_note)
+    return "\n".join(lines)
+
+
+def _format_index_quote_markdown(
+    symbol: str, ticker: object, use_delayed: bool = True
+) -> str:
+    """Render an index spot quote (bid/ask blank when IB reports the -1 sentinel)."""
+    if ticker is None:
+        return f"No quote found for index {symbol}"
+    data_type = "delayed-frozen" if use_delayed else "live"
+    return "\n".join(
+        [
+            f"# Index Quote for {symbol}",
+            f"**Data**: {data_type}",
+            "",
+            f"- **Last**: {_fmt_price(getattr(ticker, 'last', None))}",
+            f"- **Close**: {_fmt_price(getattr(ticker, 'close', None))}",
+            f"- **Bid**: {_fmt_price(getattr(ticker, 'bid', None))}",
+            f"- **Ask**: {_fmt_price(getattr(ticker, 'ask', None))}",
+        ]
+    )
+
+
+def _ticker_ready(ticker: object, last_stamp: object) -> bool:
+    """True once a ticker has received a fresh update with usable data.
+
+    ib_async reuses Ticker objects per contract for the connection's
+    lifetime, so a changed ``timestamp`` is required before trusting the
+    fields — otherwise a repeat request for the same contract would return
+    the previous call's stale values. Options wait for a price plus model
+    greeks (their last trade may be long ago or never); other contracts
+    wait for the last price (IB answers quickly with its -1/0 sentinel
+    when there is none). The caller's settle window caps the wait either way.
+    """
+    if getattr(ticker, "timestamp", None) == last_stamp:
+        return False
+
+    def _is_number(value: object) -> bool:
+        return isinstance(value, int | float) and not math.isnan(float(value))
+
+    contract = getattr(ticker, "contract", None)
+    if getattr(contract, "secType", "") == "OPT":
+        prices = (
+            getattr(ticker, "bid", None),
+            getattr(ticker, "ask", None),
+            getattr(ticker, "last", None),
+            getattr(ticker, "close", None),
+        )
+        if not any(_is_number(p) for p in prices):
+            return False
+        return getattr(ticker, "modelGreeks", None) is not None
+    return _is_number(getattr(ticker, "last", None))
+
+
 class IBMCPServer:
     """Interactive Brokers MCP Server (FastMCP edition)."""
 
@@ -161,6 +441,49 @@ class IBMCPServer:
                 elif isinstance(c, list):
                     result.extend(_flatten_contracts(c))
             return result
+
+        async def _fetch_tickers(
+            contracts: list[ib.Contract],
+            use_delayed: bool = True,
+            settle: float = _QUOTE_SETTLE_SECONDS,
+        ) -> list[ib.Ticker]:
+            # Delayed data (and option greeks) arrive as streaming ticks, not
+            # via one-shot snapshots, so subscribe briefly and cancel afterwards
+            # to free the market-data lines. The market data type is session-
+            # global, so it is set here, synchronously before subscribing, to
+            # keep concurrent calls with different types from interleaving.
+            self.ib.reqMarketDataType(4 if use_delayed else 1)
+            tickers: list[ib.Ticker] = []
+            try:
+                for c in contracts:
+                    tickers.append(
+                        self.ib.reqMktData(
+                            contract=c,
+                            genericTickList="",
+                            snapshot=False,
+                            regulatorySnapshot=False,
+                        )
+                    )
+                # ib_async reuses Ticker objects per contract for the life of
+                # the connection, so wait for a fresh update on each before
+                # returning; ``settle`` is a ceiling, not a fixed cost.
+                stamps = [getattr(t, "timestamp", None) for t in tickers]
+                loop = asyncio.get_running_loop()
+                deadline = loop.time() + settle
+                while loop.time() < deadline:
+                    await asyncio.sleep(0.25)
+                    if all(
+                        _ticker_ready(t, s)
+                        for t, s in zip(tickers, stamps, strict=True)
+                    ):
+                        break
+            finally:
+                for c in contracts[: len(tickers)]:
+                    try:
+                        self.ib.cancelMktData(c)
+                    except Exception as e:  # pragma: no cover - disconnect
+                        logger.warning("cancelMktData failed for %s: %s", c, e)
+            return tickers
 
         def _xml_to_markdown(xml_data: str) -> str:
             """Convert XML data to markdown; return as-is if not XML."""
@@ -663,6 +986,184 @@ class IBMCPServer:
             except Exception as e:  # pragma: no cover
                 return f"Error getting contract details: {e}"
 
+        @self.server.tool(
+            description=(
+                "List option-chain parameters (expirations and strikes) for an "
+                "underlying via reqSecDefOptParams. Strikes are sorted ascending, "
+                "filtered to [min_strike, max_strike] (0 = unbounded), then paginated "
+                "(max_strikes per page, default 20; strike_offset moves the window); "
+                "the output says how to fetch the next page. When several trading "
+                "classes are returned (e.g. SPX and SPXW), pass trading_class to "
+                "page one chain. Read-only; no market-data subscription required."
+            )
+        )
+        async def get_option_chain(
+            symbol: Annotated[str, "Underlying symbol (e.g., XSP, SPX, AAPL)"],
+            sec_type: Annotated[
+                str, "Underlying security type (IND, STK, ...)"
+            ] = "IND",
+            exchange: Annotated[
+                str, "Underlying exchange (CBOE for indices, SMART for stocks)"
+            ] = "CBOE",
+            currency: Annotated[str, "Currency (e.g., USD)"] = "USD",
+            trading_class: Annotated[
+                str, "Filter to a single option trading class (optional)"
+            ] = "",
+            min_strike: Annotated[float, "Lowest strike (0 = no bound)"] = 0.0,
+            max_strike: Annotated[float, "Highest strike (0 = no bound)"] = 0.0,
+            max_strikes: Annotated[
+                int, Field(description="Max strikes per page", ge=1, le=500)
+            ] = 20,
+            strike_offset: Annotated[
+                int, Field(description="Strike pagination offset", ge=0)
+            ] = 0,
+        ) -> str:
+            await _ensure_connected()
+            underlying = _create_contract(
+                symbol, sec_type=sec_type, exchange=exchange, currency=currency
+            )
+            try:
+                qualified = _flatten_contracts(
+                    await self.ib.qualifyContractsAsync(underlying)
+                )
+                if not qualified:
+                    return f"No contract found for {symbol}"
+                c = qualified[0]
+                chains = await self.ib.reqSecDefOptParamsAsync(
+                    underlyingSymbol=getattr(c, "symbol", symbol) or symbol,
+                    futFopExchange="",
+                    # Use the qualified contract's secType so conId inputs
+                    # (which qualify to their real type) work as everywhere.
+                    underlyingSecType=getattr(c, "secType", sec_type) or sec_type,
+                    underlyingConId=getattr(c, "conId", 0),
+                )
+                if trading_class:
+                    chains = [
+                        ch
+                        for ch in chains
+                        if getattr(ch, "tradingClass", "") == trading_class
+                    ]
+                return _format_option_chain_markdown(
+                    symbol,
+                    sec_type=sec_type,
+                    chains=chains,
+                    min_strike=min_strike,
+                    max_strike=max_strike,
+                    max_strikes=max_strikes,
+                    strike_offset=strike_offset,
+                )
+            except Exception as e:  # pragma: no cover
+                return f"Error getting option chain: {e}"
+
+        @self.server.tool(
+            description=(
+                "Fetch a batch of option quotes (bid/ask/last/close + model IV/delta) "
+                "for a list of strikes on one expiry/right, via a brief streaming "
+                "market-data subscription (delayed option data is not available as "
+                "one-shot snapshots). Duplicate strikes are ignored; capped at 20 "
+                "strikes per call to respect IB pacing. Defaults to delayed-frozen "
+                "data (no OPRA subscription needed); set use_delayed=false for live "
+                "data. Read-only."
+            )
+        )
+        async def get_option_quotes(
+            symbol: Annotated[str, "Underlying symbol (e.g., XSP)"],
+            expiry: Annotated[str, "Expiration date, format YYYYMMDD"],
+            right: Annotated[str, "Option right: P (put) or C (call)"],
+            strikes: Annotated[
+                list[float],
+                Field(
+                    description="Strike prices (max 20 per call)",
+                    min_length=1,
+                    max_length=_MAX_QUOTE_BATCH,
+                ),
+            ],
+            exchange: Annotated[str, "Option exchange (e.g., SMART)"] = "SMART",
+            currency: Annotated[str, "Currency (e.g., USD)"] = "USD",
+            trading_class: Annotated[
+                str, "Option trading class (defaults to the symbol)"
+            ] = "",
+            use_delayed: Annotated[
+                bool, "Use delayed-frozen data (no OPRA needed)"
+            ] = True,
+        ) -> str:
+            # Dedupe: double-subscribing one contract would leak an IB
+            # market-data line (only the newest request gets cancelled).
+            unique_strikes = sorted({float(s) for s in strikes})
+            if not unique_strikes:
+                return "Error getting option quotes: provide at least one strike"
+            if len(unique_strikes) > _MAX_QUOTE_BATCH:
+                return (
+                    f"Error getting option quotes: {len(unique_strikes)} unique "
+                    f"strikes requested; max {_MAX_QUOTE_BATCH} per call to "
+                    "respect IB pacing limits. Split into smaller batches."
+                )
+            await _ensure_connected()
+            try:
+                tclass = trading_class or symbol
+                contracts = [
+                    ib.Option(
+                        symbol=symbol,
+                        lastTradeDateOrContractMonth=expiry,
+                        strike=strike,
+                        right=right,
+                        exchange=exchange,
+                        currency=currency,
+                        tradingClass=tclass,
+                    )
+                    for strike in unique_strikes
+                ]
+                qualified = _flatten_contracts(
+                    await self.ib.qualifyContractsAsync(*contracts)
+                )
+                if not qualified:
+                    return f"No option contracts found for {symbol} {expiry} {right}"
+                tickers = await _fetch_tickers(qualified, use_delayed=use_delayed)
+                return _format_option_quotes_markdown(
+                    symbol,
+                    expiry=expiry,
+                    right=right,
+                    tickers=tickers,
+                    use_delayed=use_delayed,
+                    requested_strikes=unique_strikes,
+                )
+            except Exception as e:  # pragma: no cover
+                return f"Error getting option quotes: {e}"
+
+        @self.server.tool(
+            description=(
+                "Get the spot quote (last/close/bid/ask) for an index via a "
+                "brief streaming market-data subscription, delayed by default "
+                "(no market-data subscription needed), handy for "
+                "strike-from-spot math. Read-only."
+            )
+        )
+        async def get_index_quote(
+            symbol: Annotated[str, "Index symbol or conid (e.g., XSP, SPX)"],
+            exchange: Annotated[str, "Index exchange (e.g., CBOE)"] = "CBOE",
+            currency: Annotated[str, "Currency (e.g., USD)"] = "USD",
+            use_delayed: Annotated[
+                bool, "Use delayed-frozen data (no OPRA needed)"
+            ] = True,
+        ) -> str:
+            await _ensure_connected()
+            index = _create_contract(
+                symbol, sec_type="IND", exchange=exchange, currency=currency
+            )
+            try:
+                qualified = _flatten_contracts(
+                    await self.ib.qualifyContractsAsync(index)
+                )
+                if not qualified:
+                    return f"No index found for {symbol}"
+                tickers = await _fetch_tickers([qualified[0]], use_delayed=use_delayed)
+                ticker = tickers[0] if tickers else None
+                return _format_index_quote_markdown(
+                    symbol, ticker, use_delayed=use_delayed
+                )
+            except Exception as e:  # pragma: no cover
+                return f"Error getting index quote: {e}"
+
         # Keep references on self to make tools reachable in tests/REPL if needed
         self.lookup_contract = lookup_contract  # type: ignore[attr-defined]
         self.ticker_to_conid = ticker_to_conid  # type: ignore[attr-defined]
@@ -673,6 +1174,9 @@ class IBMCPServer:
         self.get_account_summary = get_account_summary  # type: ignore[attr-defined]
         self.get_positions = get_positions  # type: ignore[attr-defined]
         self.get_contract_details = get_contract_details  # type: ignore[attr-defined]
+        self.get_option_chain = get_option_chain  # type: ignore[attr-defined]
+        self.get_option_quotes = get_option_quotes  # type: ignore[attr-defined]
+        self.get_index_quote = get_index_quote  # type: ignore[attr-defined]
 
     def run(
         self,

--- a/tests/test_option_tools.py
+++ b/tests/test_option_tools.py
@@ -1,0 +1,368 @@
+# ruff: noqa: S101
+#!/usr/bin/env python3
+"""Tests for the read-only option tools (chain, quotes, index).
+
+Fixtures use values captured from a live IBKR **delayed** feed for XSP on
+2026-07-15: subsets of the real strike ladder and expiration list, the
+three routing exchanges XSP lists under (IBUSOPT, CBOE, SMART), the
+pre-market all-blank quote snapshot, and IB's -1 "no data" price sentinel
+observed on the index feed. No live connection is made in these tests.
+"""
+
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ib_mcp.server import (  # type: ignore  # noqa: E402
+    IBMCPServer,
+    _fmt_num,
+    _fmt_price,
+    _format_index_quote_markdown,
+    _format_option_chain_markdown,
+    _format_option_quotes_markdown,
+    _ticker_ready,
+)
+
+# Real XSP reference data (subsets), captured 2026-07-15. Strikes are spaced
+# every 5 points in this range; expirations are from the live chain.
+_XSP_EXPIRATIONS = ["20260715", "20260821", "20260828", "20261218", "20271217"]
+_XSP_STRIKES = [
+    440.0,
+    445.0,
+    450.0,
+    455.0,
+    460.0,
+    465.0,
+    470.0,
+    475.0,
+    480.0,
+    485.0,
+    490.0,
+]
+
+
+def _chain(
+    exchange: str,
+    strikes: list[float] | None = None,
+    expirations: list[str] | None = None,
+    trading_class: str = "XSP",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        tradingClass=trading_class,
+        exchange=exchange,
+        multiplier="100",
+        expirations=list(_XSP_EXPIRATIONS if expirations is None else expirations),
+        strikes=list(_XSP_STRIKES if strikes is None else strikes),
+    )
+
+
+def _ticker(
+    strike: float,
+    bid: float | None = None,
+    ask: float | None = None,
+    last: float | None = None,
+    close: float | None = None,
+    greeks: object | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        contract=SimpleNamespace(strike=strike),
+        bid=bid,
+        ask=ask,
+        last=last,
+        close=close,
+        modelGreeks=greeks,
+    )
+
+
+def test_option_chain_range_filter_and_pagination() -> None:
+    """Filter to [450, 480] -> 7 strikes, paged 3 at a time."""
+    chains = [_chain("SMART")]
+    page1 = _format_option_chain_markdown(
+        "XSP",
+        sec_type="IND",
+        chains=chains,
+        min_strike=450,
+        max_strike=480,
+        max_strikes=3,
+    )
+    assert "of 7 in range [450, 480]" in page1
+    assert "450, 455, 460" in page1
+    assert "pass strike_offset=3" in page1
+    assert "465" not in page1  # on a later page, not shown yet
+
+    page2 = _format_option_chain_markdown(
+        "XSP",
+        sec_type="IND",
+        chains=chains,
+        min_strike=450,
+        max_strike=480,
+        max_strikes=3,
+        strike_offset=3,
+    )
+    assert "465, 470, 475" in page2
+    assert "pass strike_offset=6" in page2
+
+
+def test_option_chain_no_next_page_hint_on_final_page() -> None:
+    """The last page (offset > 0, window ends at total) offers no next page."""
+    chains = [_chain("SMART")]
+    out = _format_option_chain_markdown(
+        "XSP",
+        sec_type="IND",
+        chains=chains,
+        min_strike=450,
+        max_strike=480,
+        max_strikes=3,
+        strike_offset=6,
+    )
+    assert "Strikes 7–7 of 7" in out
+    assert "next page" not in out
+
+
+def test_option_chain_offset_past_end_is_reported_honestly() -> None:
+    """Paging past the end names the overshoot instead of 'none in range'."""
+    chains = [_chain("SMART")]
+    out = _format_option_chain_markdown(
+        "XSP",
+        sec_type="IND",
+        chains=chains,
+        min_strike=450,
+        max_strike=480,
+        max_strikes=3,
+        strike_offset=7,
+    )
+    assert "strike_offset=7 is past the last strike" in out
+    assert "valid offsets: 0-6" in out
+    assert "none in range" not in out
+
+
+def test_option_chain_single_bound_uses_prose_wording() -> None:
+    """Single-sided filters read as prose, not pseudo-math infinities."""
+    chains = [_chain("SMART")]
+    out = _format_option_chain_markdown(
+        "XSP", sec_type="IND", chains=chains, min_strike=470, max_strikes=10
+    )
+    assert "at or above 470" in out
+    assert "inf" not in out
+
+
+def test_option_chain_sorts_unsorted_strikes() -> None:
+    """Strikes render ascending regardless of input order (deterministic paging)."""
+    chains = [_chain("SMART", strikes=[470.0, 440.0, 460.0, 450.0])]
+    out = _format_option_chain_markdown(
+        "XSP", sec_type="IND", chains=chains, max_strikes=10
+    )
+    assert "440, 450, 460, 470" in out
+
+
+def test_option_chain_dedups_identical_routing_exchanges() -> None:
+    """XSP lists the same class on 3 exchanges; collapse to one section."""
+    chains = [_chain("IBUSOPT"), _chain("CBOE"), _chain("SMART")]
+    out = _format_option_chain_markdown(
+        "XSP", sec_type="IND", chains=chains, max_strikes=50
+    )
+    assert out.count("## Trading Class") == 1
+    assert "exchanges: IBUSOPT, CBOE, SMART" in out
+
+
+def test_option_chain_multiple_classes_advise_trading_class() -> None:
+    """SPX-style multi-class chains skip per-group hints and advise filtering.
+
+    One strike_offset cannot page two different strike lists, so the output
+    must not emit contradictory per-group next-page hints.
+    """
+    chains = [
+        _chain("SMART", trading_class="SPX", strikes=[4000.0, 4100.0, 4200.0]),
+        _chain(
+            "SMART",
+            trading_class="SPXW",
+            strikes=[4000.0, 4050.0, 4100.0, 4150.0, 4200.0],
+        ),
+    ]
+    out = _format_option_chain_markdown(
+        "SPX", sec_type="IND", chains=chains, max_strikes=2
+    )
+    assert out.count("## Trading Class") == 2
+    assert "next page" not in out
+    assert "pass trading_class to page one chain reliably" in out
+    assert "trading classes: SPX, SPXW" in out
+
+
+def test_option_quotes_blank_cells_for_no_data() -> None:
+    """None (pre-market) and IB -1/0 sentinels render as blank cells, not nan/-1."""
+    tickers = [
+        _ticker(530.0),  # real pre-market snapshot: all None
+        _ticker(490.0, bid=-1.0, ask=-1.0, last=0.0, close=-1.0),  # -1/0 sentinels
+    ]
+    out = _format_option_quotes_markdown(
+        "XSP", expiry="20260828", right="P", tickers=tickers
+    )
+    assert "| 490 |  |  |  |  |  |  |" in out
+    assert "| 530 |  |  |  |  |  |  |" in out
+    assert "nan" not in out.lower()
+    assert "-1" not in out
+    assert "None" not in out
+
+
+def test_option_quotes_skips_unlisted_strikes() -> None:
+    """Strikes not listed for the expiry are reported, not silently dropped."""
+    tickers = [_ticker(530.0)]
+    out = _format_option_quotes_markdown(
+        "XSP",
+        expiry="20260828",
+        right="P",
+        tickers=tickers,
+        requested_strikes=[455.0, 530.0, 604.0],
+    )
+    assert "Not listed for this expiry (skipped): 455, 604" in out
+
+
+def test_option_quotes_empty_reports_all_missing() -> None:
+    """When nothing qualifies, say so and list the requested strikes."""
+    out = _format_option_quotes_markdown(
+        "XSP",
+        expiry="20260828",
+        right="P",
+        tickers=[],
+        requested_strikes=[455.0, 530.0],
+    )
+    assert "No option quotes found for XSP 20260828 P" in out
+    assert "Not listed for this expiry (skipped): 455, 530" in out
+
+
+async def test_option_quotes_batch_cap_rejects_oversized_request() -> None:
+    """>20 unique strikes is rejected before any connection (offline-safe)."""
+    server = IBMCPServer()
+    strikes = [float(400 + i) for i in range(21)]
+    out = await server.get_option_quotes(
+        "XSP", expiry="20260828", right="P", strikes=strikes
+    )
+    assert "max 20" in out
+    assert "21 unique strikes" in out
+
+
+async def test_option_quotes_batch_cap_counts_unique_strikes() -> None:
+    """Duplicate strikes are deduped before the cap (they would leak IB
+    market-data lines if subscribed twice), so the error names the unique
+    count, not the raw length."""
+    server = IBMCPServer()
+    strikes = [float(400 + i) for i in range(21)] + [400.0, 401.0, 402.0]
+    out = await server.get_option_quotes(
+        "XSP", expiry="20260828", right="P", strikes=strikes
+    )
+    assert "21 unique strikes" in out  # 24 raw values, 21 unique
+
+
+async def test_option_quotes_requires_at_least_one_strike() -> None:
+    """An empty strike list is rejected before any connection."""
+    server = IBMCPServer()
+    out = await server.get_option_quotes(
+        "XSP", expiry="20260828", right="P", strikes=[]
+    )
+    assert "at least one strike" in out
+
+
+def test_fmt_price_blanks_sentinels_and_missing() -> None:
+    """Prices blank on None/NaN and IB's -1/0 'no data' sentinels."""
+    assert _fmt_price(8.2) == "8.20"
+    assert _fmt_price(None) == ""
+    assert _fmt_price(-1.0) == ""  # IB no-data sentinel (seen on the index feed)
+    assert _fmt_price(0.0) == ""  # no bid / no data
+    assert _fmt_price(float("nan")) == ""
+
+
+def test_fmt_num_preserves_negative_delta() -> None:
+    """Greeks keep their sign: a put delta is legitimately negative."""
+    assert _fmt_num(-0.4210, decimals=4) == "-0.4210"
+    assert _fmt_num(0.1523, decimals=4) == "0.1523"
+    assert _fmt_num(None) == ""
+    assert _fmt_num(float("nan")) == ""
+
+
+def test_ticker_ready_requires_fresh_timestamp() -> None:
+    """A reused ticker with an unchanged timestamp is stale, not ready.
+
+    ib_async caches Ticker objects per contract for the connection's
+    lifetime; without the freshness check, a repeat call for the same
+    contract would return the previous call's values.
+    """
+    ticker = _ticker(758.0, bid=13.24, ask=13.54, close=14.58, greeks=object())
+    ticker.contract.secType = "OPT"
+    ticker.timestamp = 1000.0
+    assert _ticker_ready(ticker, 1000.0) is False  # unchanged -> stale
+    assert _ticker_ready(ticker, 999.0) is True  # fresh batch arrived
+
+
+def test_ticker_ready_gates_options_on_greeks_and_prices() -> None:
+    """Options need a price field and model greeks; indices need last."""
+    nan = float("nan")
+    option = _ticker(758.0, bid=nan, ask=nan, last=nan, close=nan)
+    option.contract.secType = "OPT"
+    option.timestamp = 2.0
+    assert _ticker_ready(option, 1.0) is False  # fresh but no data yet
+
+    option.bid = 13.24
+    assert _ticker_ready(option, 1.0) is False  # price but no greeks yet
+    option.modelGreeks = object()
+    assert _ticker_ready(option, 1.0) is True
+
+    index = SimpleNamespace(
+        contract=SimpleNamespace(secType="IND"),
+        bid=-1.0,
+        ask=nan,
+        last=nan,  # close/bid alone are not enough: wait for last
+        close=754.36,
+        modelGreeks=None,
+        timestamp=2.0,
+    )
+    assert _ticker_ready(index, 1.0) is False
+    index.last = 0.0  # IB's answered no-trade sentinel counts as done
+    assert _ticker_ready(index, 1.0) is True
+    index.last = 757.23
+    assert _ticker_ready(index, 1.0) is True
+
+
+def test_index_quote_blanks_sentinel_bid_ask() -> None:
+    """Index shows last/close; IB's -1 bid/ask sentinels render blank (captured XSP)."""
+    ticker = SimpleNamespace(last=754.43, close=754.36, bid=-1.0, ask=-1.0)
+    out = _format_index_quote_markdown("XSP", ticker)
+    assert "**Last**: 754.43" in out
+    assert "**Close**: 754.36" in out
+    assert "-1" not in out
+    bid_line = next(line for line in out.splitlines() if "Bid" in line)
+    assert bid_line.strip() == "- **Bid**:"
+
+
+def test_option_quotes_render_real_populated_rows() -> None:
+    """Real delayed XSP put quotes (captured 2026-07-15) render with greeks.
+
+    Values are the exact delayed-feed snapshot: strike 700 has a last trade,
+    strike 758 does not (blank), and both deltas are negative (puts).
+    """
+    tickers = [
+        _ticker(
+            700.0,
+            bid=3.03,
+            ask=3.24,
+            last=3.16,
+            close=3.48,
+            greeks=SimpleNamespace(impliedVol=0.2024, delta=-0.1155, undPrice=None),
+        ),
+        _ticker(
+            758.0,
+            bid=13.24,
+            ask=13.54,
+            last=float("nan"),
+            close=14.58,
+            greeks=SimpleNamespace(impliedVol=0.1368, delta=-0.4685, undPrice=None),
+        ),
+    ]
+    out = _format_option_quotes_markdown(
+        "XSP", expiry="20260828", right="P", tickers=tickers
+    )
+    assert "| 700 | 3.03 | 3.24 | 3.16 | 3.48 | 0.2024 | -0.1155 |" in out
+    assert "| 758 | 13.24 | 13.54 |  | 14.58 | 0.1368 | -0.4685 |" in out


### PR DESCRIPTION
# feat: add read-only option chain, quote, and index tools

Closes #31.

## Motivation

The only Market Data tool today is `get_historical_data` (historical bars, hardcoded
`STK`). LLM-driven options workflows need to discover an option chain, pull quotes/greeks
for a chosen tranche of contracts, and read the underlying spot to reason about moneyness.
This adds three **read-only** tools for that, using `ib_async`'s existing API — **no new
runtime dependencies** and no changes to existing tool signatures or behavior.

## What's added

- **`get_option_chain`** — expirations + a filtered, paginated strike window via
  `reqSecDefOptParams` (contract reference data; no market-data subscription needed).
- **`get_option_quotes`** — batch bid/ask/last/close + model IV/delta for a list of
  strikes, via a brief streaming `reqMktData` subscription.
- **`get_index_quote`** — index spot (last/close/bid/ask); accepts a symbol or conId.

All markdown-building logic lives in small module-level `_format_*` / `_fmt_*` helpers
(mirroring `_format_positions_markdown`), so it is unit-tested without a live connection.

## Design choices

- **Read-only preserved** — no order placement/modification/cancellation; `readonly=True`
  untouched; nothing new phones home.
- **Streaming, not snapshots, for quotes** — on an account without an options subscription,
  `reqTickers` snapshots come back empty; delayed ticks and model greeks only arrive via
  streaming. The quote tools therefore `reqMktData`, wait for each ticker to receive a
  fresh update (bounded by a 4s ceiling — typical calls finish in ~1s), then
  `cancelMktData` to free the market-data lines. The freshness check matters because
  `ib_async` caches Ticker objects per contract for the connection's lifetime; without it,
  repeat calls for the same contract would return the previous call's values.
- **Delayed-data fallback** — quote tools default to `reqMarketDataType(4)`
  (delayed-frozen), so they work without an OPRA subscription and outside RTH;
  `use_delayed=false` requests live data. The market data type is a session-global IB
  setting: it is set synchronously right next to the subscriptions it governs (so
  concurrent calls cannot interleave different types), but the last-set type does persist
  on the session. No existing tool consumes streaming market data, so current behavior is
  unaffected — flagging it here for transparency.
- **Batch quotes with a pacing cap** — up to 20 strikes per `get_option_quotes` call,
  enforced both in the JSON schema (`minItems`/`maxItems`, visible to clients) and at
  runtime. Duplicate strikes are deduped: double-subscribing one contract would orphan an
  IB market-data line (`ib_async` tracks one reqId per contract, so only the newest
  subscription gets cancelled).
- **Deterministic strike pagination** — strikes are sorted ascending (expirations
  chronologically) before filtering to `[min_strike, max_strike]` and paging via
  `max_strikes`/`strike_offset`; the output states when and how to fetch the next page,
  and paging past the end is reported explicitly. When an underlying returns several
  trading classes (e.g. SPX and SPXW), one offset cannot page different strike ladders,
  so the output names the classes and advises filtering with `trading_class` instead of
  emitting contradictory per-class hints.
- **Chain dedup** — an underlying that lists the same class on several routing exchanges
  (e.g. XSP on IBUSOPT/CBOE/SMART) is collapsed into one section listing the exchanges.
- **Sentinel-safe rendering** — IB reports `-1` (or `0` with zero size) when a side has no
  quote; prices render those as blank cells rather than misleading `-1.00`, while greeks
  keep their sign (a put delta is negative).
- **Fail loud** — strikes not listed for the requested expiry are reported
  (`Not listed for this expiry (skipped): …`), not silently dropped.

## No order capability by design

This stays a strictly read-only data server. No trading tools were added.

## Testing

- 19 new unit tests for the pure formatters and guards (range filter + pagination +
  final-page/overshoot/multi-class behavior, exchange dedup, NaN/sentinel blanking,
  skipped-strikes note, ticker-readiness gating incl. the stale-cache case, batch cap and
  dedupe-before-cap), using `SimpleNamespace` fixtures seeded from values **captured from
  a live IBKR delayed feed for XSP on 2026-07-15**. No live connection in CI.
- `ruff check .`, `mypy ib_mcp`, `pytest -q` green (Python 3.12 and 3.13); black/isort
  clean; new code also passes the pinned pre-commit ruff.

## Manual test (local IB Gateway, delayed data, read-only, no OPRA subscription)

`get_option_chain("XSP", min_strike=440, max_strike=490, max_strikes=12)` — 0.2s; the
three routing exchanges collapse into one section:

```
# Option Chain for XSP (IND)
## Trading Class XSP (exchanges: IBUSOPT, CBOE, SMART, multiplier 100)
**Expirations (46)**: 20260716, 20260717, ... , 20281215
**Strikes 1–11 of 11 in range [440, 490]**: 440, 445, 450, 455, 460, 465, 470, 475, 480, 485, 490
```

`get_option_quotes("XSP", expiry="20260828", right="P", strikes=[530, 700, 750, 758, 758])`
— ~1s; note the duplicate 758 collapses to one row, the volatility smile, and the delta
gradient from deep-OTM to near-ATM (delayed model greeks, no OPRA):

```
# Option Quotes for XSP 20260828 P
**Expiry**: 20260828 | **Right**: P | **Data**: delayed-frozen
| Strike | Bid | Ask | Last | Close | IV | Delta |
| --- | --- | --- | --- | --- | --- | --- |
| 530 | 0.25 | 0.32 |  | 0.27 | 0.4386 | -0.0071 |
| 700 | 3.10 | 3.21 |  | 2.92 | 0.2023 | -0.1193 |
| 750 | 10.80 | 11.24 |  | 10.25 | 0.1439 | -0.4037 |
| 758 | 13.55 | 14.01 |  | 12.86 | 0.1350 | -0.4885 |
*IV/Delta from IB model greeks; blank cells mean no data or no bid (illiquid strike or market closed).*
```

`get_index_quote("XSP")` — ~1.3s; bid/ask/last came back as IB's no-data sentinels in this
session (no index subscription) and render blank; repeat calls return fresh data, not the
first call's cached values:

```
# Index Quote for XSP
**Data**: delayed-frozen
- **Last**:
- **Close**: 757.24
- **Bid**:
- **Ask**:
```

`get_index_quote("137851301")` (conId input) resolves and returns the same quote.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
