### PR TITLE
fix: address review feedback from #32

### DIFF
--- a/ib_mcp/server.py
+++ b/ib_mcp/server.py
@@ -346,9 +346,11 @@ def _ticker_ready(ticker: object, last_stamp: object) -> bool:
     lifetime, so a changed ``timestamp`` is required before trusting the
     fields — otherwise a repeat request for the same contract would return
     the previous call's stale values. Options wait for a price plus model
-    greeks (their last trade may be long ago or never); other contracts
-    wait for the last price (IB answers quickly with its -1/0 sentinel
-    when there is none). The caller's settle window caps the wait either way.
+    greeks (their last trade may be long ago or never); other contracts are
+    ready on a last *or* close price — an index that has not traded may report
+    NaN for last, and requiring it would burn the caller's whole settle window
+    before returning the close it already had. The settle window caps the wait
+    either way.
     """
     if getattr(ticker, "timestamp", None) == last_stamp:
         return False
@@ -367,7 +369,9 @@ def _ticker_ready(ticker: object, last_stamp: object) -> bool:
         if not any(_is_number(p) for p in prices):
             return False
         return getattr(ticker, "modelGreeks", None) is not None
-    return _is_number(getattr(ticker, "last", None))
+    return _is_number(getattr(ticker, "last", None)) or _is_number(
+        getattr(ticker, "close", None)
+    )
 
 
 class IBMCPServer:
@@ -386,6 +390,9 @@ class IBMCPServer:
         self.client_id = client_id
         self.connected = False
         self.news_provider_codes: str = ""
+        # The market data type is a session-global setting, so serialize the
+        # whole set -> subscribe -> settle -> cancel cycle behind this lock.
+        self._market_data_lock = asyncio.Lock()
 
         # Register FastMCP tools
         self._register_handlers()
@@ -450,39 +457,41 @@ class IBMCPServer:
             # Delayed data (and option greeks) arrive as streaming ticks, not
             # via one-shot snapshots, so subscribe briefly and cancel afterwards
             # to free the market-data lines. The market data type is session-
-            # global, so it is set here, synchronously before subscribing, to
-            # keep concurrent calls with different types from interleaving.
-            self.ib.reqMarketDataType(4 if use_delayed else 1)
+            # global and setting it synchronously is not enough on its own: a
+            # concurrent call with the opposite use_delayed could flip it during
+            # the settle await, so the whole cycle runs under the lock.
             tickers: list[ib.Ticker] = []
-            try:
-                for c in contracts:
-                    tickers.append(
-                        self.ib.reqMktData(
-                            contract=c,
-                            genericTickList="",
-                            snapshot=False,
-                            regulatorySnapshot=False,
+            async with self._market_data_lock:
+                self.ib.reqMarketDataType(4 if use_delayed else 1)
+                try:
+                    for c in contracts:
+                        tickers.append(
+                            self.ib.reqMktData(
+                                contract=c,
+                                genericTickList="",
+                                snapshot=False,
+                                regulatorySnapshot=False,
+                            )
                         )
-                    )
-                # ib_async reuses Ticker objects per contract for the life of
-                # the connection, so wait for a fresh update on each before
-                # returning; ``settle`` is a ceiling, not a fixed cost.
-                stamps = [getattr(t, "timestamp", None) for t in tickers]
-                loop = asyncio.get_running_loop()
-                deadline = loop.time() + settle
-                while loop.time() < deadline:
-                    await asyncio.sleep(0.25)
-                    if all(
-                        _ticker_ready(t, s)
-                        for t, s in zip(tickers, stamps, strict=True)
-                    ):
-                        break
-            finally:
-                for c in contracts[: len(tickers)]:
-                    try:
-                        self.ib.cancelMktData(c)
-                    except Exception as e:  # pragma: no cover - disconnect
-                        logger.warning("cancelMktData failed for %s: %s", c, e)
+                    # ib_async reuses Ticker objects per contract for the life
+                    # of the connection, so wait for a fresh update on each
+                    # before returning; ``settle`` is a ceiling, not a fixed cost.
+                    stamps = [getattr(t, "timestamp", None) for t in tickers]
+                    loop = asyncio.get_running_loop()
+                    deadline = loop.time() + settle
+                    while loop.time() < deadline:
+                        await asyncio.sleep(0.25)
+                        if all(
+                            _ticker_ready(t, s)
+                            for t, s in zip(tickers, stamps, strict=True)
+                        ):
+                            break
+                finally:
+                    for c in contracts[: len(tickers)]:
+                        try:
+                            self.ib.cancelMktData(c)
+                        except Exception as e:  # pragma: no cover - disconnect
+                            logger.warning("cancelMktData failed for %s: %s", c, e)
             return tickers
 
         def _xml_to_markdown(xml_data: str) -> str:
@@ -1029,12 +1038,14 @@ class IBMCPServer:
                 if not qualified:
                     return f"No contract found for {symbol}"
                 c = qualified[0]
+                # Use the qualified contract's secType so conId inputs (which
+                # qualify to their real type) work as everywhere else — and so
+                # the rendered header agrees with what was actually requested.
+                qualified_sec_type = getattr(c, "secType", sec_type) or sec_type
                 chains = await self.ib.reqSecDefOptParamsAsync(
                     underlyingSymbol=getattr(c, "symbol", symbol) or symbol,
                     futFopExchange="",
-                    # Use the qualified contract's secType so conId inputs
-                    # (which qualify to their real type) work as everywhere.
-                    underlyingSecType=getattr(c, "secType", sec_type) or sec_type,
+                    underlyingSecType=qualified_sec_type,
                     underlyingConId=getattr(c, "conId", 0),
                 )
                 if trading_class:
@@ -1045,7 +1056,7 @@ class IBMCPServer:
                     ]
                 return _format_option_chain_markdown(
                     symbol,
-                    sec_type=sec_type,
+                    sec_type=qualified_sec_type,
                     chains=chains,
                     min_strike=min_strike,
                     max_strike=max_strike,
@@ -1073,7 +1084,7 @@ class IBMCPServer:
             strikes: Annotated[
                 list[float],
                 Field(
-                    description="Strike prices (max 20 per call)",
+                    description="Strike prices (max 20 per call, duplicates ignored)",
                     min_length=1,
                     max_length=_MAX_QUOTE_BATCH,
                 ),
@@ -1087,17 +1098,20 @@ class IBMCPServer:
                 bool, "Use delayed-frozen data (no OPRA needed)"
             ] = True,
         ) -> str:
+            # Count the raw list, matching the schema's max_length, so a direct
+            # call is rejected by the same rule (and gets the same message) that
+            # schema validation applies to MCP clients.
+            if not strikes:
+                return "Error getting option quotes: provide at least one strike"
+            if len(strikes) > _MAX_QUOTE_BATCH:
+                return (
+                    f"Error getting option quotes: {len(strikes)} strikes "
+                    f"requested; max {_MAX_QUOTE_BATCH} per call to respect IB "
+                    "pacing limits. Split into smaller batches."
+                )
             # Dedupe: double-subscribing one contract would leak an IB
             # market-data line (only the newest request gets cancelled).
             unique_strikes = sorted({float(s) for s in strikes})
-            if not unique_strikes:
-                return "Error getting option quotes: provide at least one strike"
-            if len(unique_strikes) > _MAX_QUOTE_BATCH:
-                return (
-                    f"Error getting option quotes: {len(unique_strikes)} unique "
-                    f"strikes requested; max {_MAX_QUOTE_BATCH} per call to "
-                    "respect IB pacing limits. Split into smaller batches."
-                )
             await _ensure_connected()
             try:
                 tclass = trading_class or symbol

--- a/tests/test_option_tools.py
+++ b/tests/test_option_tools.py
@@ -14,6 +14,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
@@ -235,26 +237,40 @@ def test_option_quotes_empty_reports_all_missing() -> None:
 
 
 async def test_option_quotes_batch_cap_rejects_oversized_request() -> None:
-    """>20 unique strikes is rejected before any connection (offline-safe)."""
+    """>20 strikes is rejected before any connection (offline-safe).
+
+    The runtime counts the raw list, exactly as the schema's max_length does,
+    so direct calls and MCP clients are held to the same rule.
+    """
     server = IBMCPServer()
     strikes = [float(400 + i) for i in range(21)]
     out = await server.get_option_quotes(
         "XSP", expiry="20260828", right="P", strikes=strikes
     )
     assert "max 20" in out
-    assert "21 unique strikes" in out
+    assert "21 strikes" in out
 
 
-async def test_option_quotes_batch_cap_counts_unique_strikes() -> None:
-    """Duplicate strikes are deduped before the cap (they would leak IB
-    market-data lines if subscribed twice), so the error names the unique
-    count, not the raw length."""
+async def test_option_quotes_dedupes_duplicate_strikes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Duplicates within the cap are deduped (subscribing one contract twice
+    would leak an IB market-data line), so they never reach qualification."""
     server = IBMCPServer()
-    strikes = [float(400 + i) for i in range(21)] + [400.0, 401.0, 402.0]
+    captured: list[float] = []
+
+    async def fake_qualify(*contracts: object) -> list[object]:
+        captured.extend(getattr(c, "strike", 0.0) for c in contracts)
+        return []
+
+    monkeypatch.setattr(server.ib, "qualifyContractsAsync", fake_qualify)
+    server.connected = True  # skip connecting; only the dedupe path is exercised
+
     out = await server.get_option_quotes(
-        "XSP", expiry="20260828", right="P", strikes=strikes
+        "XSP", expiry="20260828", right="P", strikes=[450.0, 450.0, 455.0]
     )
-    assert "21 unique strikes" in out  # 24 raw values, 21 unique
+    assert captured == [450.0, 455.0]  # 3 raw values -> 2 unique contracts
+    assert "No option contracts found" in out
 
 
 async def test_option_quotes_requires_at_least_one_strike() -> None:
@@ -298,7 +314,7 @@ def test_ticker_ready_requires_fresh_timestamp() -> None:
 
 
 def test_ticker_ready_gates_options_on_greeks_and_prices() -> None:
-    """Options need a price field and model greeks; indices need last."""
+    """Options need a price field and model greeks; indices need last or close."""
     nan = float("nan")
     option = _ticker(758.0, bid=nan, ask=nan, last=nan, close=nan)
     option.contract.secType = "OPT"
@@ -310,15 +326,20 @@ def test_ticker_ready_gates_options_on_greeks_and_prices() -> None:
     option.modelGreeks = object()
     assert _ticker_ready(option, 1.0) is True
 
+    # An index that has not traded reports NaN for last; close alone must be
+    # enough or the call would burn its whole settle window for data it has.
     index = SimpleNamespace(
         contract=SimpleNamespace(secType="IND"),
         bid=-1.0,
         ask=nan,
-        last=nan,  # close/bid alone are not enough: wait for last
+        last=nan,
         close=754.36,
         modelGreeks=None,
         timestamp=2.0,
     )
+    assert _ticker_ready(index, 1.0) is True
+
+    index.close = nan  # neither last nor close yet -> keep waiting
     assert _ticker_ready(index, 1.0) is False
     index.last = 0.0  # IB's answered no-trade sentinel counts as done
     assert _ticker_ready(index, 1.0) is True


### PR DESCRIPTION
# fix: address review feedback from #32

Thanks for the detailed review on #32 — this picks up the follow-ups you raised
there. All four are in the option tools that PR added; no new dependencies, no new
tools, and the server stays read-only.

## What changed

**1. `reqMarketDataType` race during the settle await** (your first point)

You were right that the synchronous set doesn't prevent interleaving: a concurrent
call with the opposite `use_delayed` could flip the session-global type during the
`await asyncio.sleep(0.25)` loop. The whole cycle — set type → subscribe → settle →
cancel — now runs under an `asyncio.Lock`, and the comment no longer claims more than
the code delivers.

**2. `get_index_quote` waiting on `last`**

An index that hasn't traded can report `NaN` (rather than the `-1` sentinel) for
`last`, so readiness never tripped and the call burned its full settle window before
returning the `close` it already had. Readiness now accepts `last` *or* `close` for
non-option contracts. This is safe because the freshness check (a changed
`ticker.timestamp`) already runs first, so an accepted `close` is from this call's
update, not a stale cached one.

**3. `get_option_chain` header vs fetched `secType`**

The chain was fetched with the qualified `secType` but the header rendered the
requested one. Both now use the qualified value, so a conId input (which qualifies to
its real type) renders a header that agrees with what was actually requested.

**4. Schema vs runtime strike-cap counting**

The schema's `maxItems` counts raw items while the runtime counted unique ones, so a
client sending 21 all-unique strikes got a generic validation error instead of the
tailored message. The runtime now counts the raw list too, so both apply the same
rule and direct callers get the same message MCP clients do. Duplicates are still
deduped afterwards, so one contract is never subscribed twice (that would leak a
market-data line).

Your second point — the batch settle being gated on the slowest ticker — is left as
is, since it's bounded and documented, as you noted.

## Testing

- Updated the affected unit tests and added coverage for the new behaviour: index
  readiness on `close` alone (and still waiting when neither `last` nor `close` has
  arrived), and the raw-count cap plus the dedupe that follows it.
- `ruff check .`, `mypy ib_mcp`, `pytest -q` green on 3.12 and 3.13; black/isort clean.
- Verified against a local IB Gateway with the read-only API enabled, including two
  concurrent calls with opposite `use_delayed` to exercise the new lock: the call
  that asked for delayed data still received delayed data while a live-mode call ran
  alongside it.

## Note on #36

This adds its lock in the same spot in `__init__` as #36 does, so whichever lands
second will need a trivial rebase — happy to do that whenever suits you.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
